### PR TITLE
Change colorscales, legend, and balance definition

### DIFF
--- a/app/.devcontainer/devcontainer.json
+++ b/app/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "name": "TIP-stripes",
+    "name": "TIP-app",
     // "dockerComposeFile": [
     // 	"../docker-compose.yml",
     // 	"docker-compose.extend.yml"

--- a/app/README.md
+++ b/app/README.md
@@ -4,14 +4,21 @@ We work using LTAP. Local runs on dev containers (see below). All TAP environmen
 
 ## Start Dev Container
 
-Visual Studio Code will detect that you are working in a Dev Container, click "Reopen in Container" to start the Dev container. After you reopen visual studio code in a devcontainer you are ready to start the backend and frontend, run the following commands in two seperate terminals:
+Visual Studio Code will detect that you are working in a Dev Container, click "Reopen in Container" to start the Dev container. Make sure there is an .env file for local development present in the `/frontend` folder, like this:
 
 ```
-cd frontend
-npm run dev
+WAGTAIL_API_URL=http://localhost:8000/wt/api/nextjs
+NEXT_PUBLIC_WAGTAIL_API_URL=http://localhost:8000/wt/api/nextjs
+NEXT_PUBLIC_API_URL=http://localhost:8000/api
+NEXT_PUBLIC_REKENKERN_API_URL=http://localhost:7000
+```
 
-cd src
-python manage.py runserver
+After you reopen visual studio code in a devcontainer you are ready to start the backend and frontend, run the following commands in two seperate terminals:
+
+```
+cd frontend && npm run dev
+
+cd src && python manage.py runserver
 ```
 
 For the frontend Prettier and EsLin1t is used. Make sure you installed these extenstions in your VSCode. These extensions are automatically installed in the dev container:

--- a/hail/README.md
+++ b/hail/README.md
@@ -22,10 +22,11 @@ If you prefer to use Visual Studio Code (VSCode) instead, follow these steps:
 
 1. Install [VSCode](https://code.visualstudio.com/) on your system.
 2. Clone the repository using `git clone`
-3. Open the project directory in VSCode: `code pMIEK-tool`
+3. Open the hail project directory in VSCode: `code hail` (this is **not** the root project folder, but 1 level deeper)
+4. setup .env for the dev container, just copy the example and rename to `.env`
 4. Install the `Dev Containers` extension in VSCode
 5. Reopen the window in container using `CTRL + SHIFT + P` > "Dev Containers: Reopen in container"
-6. Browse `localhost:7000/docs` to see the FastAPI docs
+6. Browse `localhost:7000/docs` to see the FastAPI docs, it starts automatically
 
 ### Production build
 

--- a/hail/config/results/maps/_shared.py
+++ b/hail/config/results/maps/_shared.py
@@ -26,6 +26,7 @@ STATIC_MAP_DATA = StaticMapData(
         name: StationData(invoeding=station["invoeding"], afname=station["afname"])
         for name, station in hsms_capacity.items()
     },
+    # replace 0.0 with None
     gm_to_station_share={
         name: {
             gmid: (this_share if this_share != 0.0 else None)

--- a/hail/config/results/maps/allcarriersbalance.py
+++ b/hail/config/results/maps/allcarriersbalance.py
@@ -20,14 +20,16 @@ from config.results.maps.gas_shared import fuel_demand, fuel_potential_and_produ
 class AllCarriersBalanceNormalized(AbstractResultMap):
 
     key = "all_carriers_balance_normalized"
-    name = "Totale energiebalans (percentage)"
+    name = "Energiebalans, aanbod-vraag ratio (%)"
     unit = "%"
     colormap = ColorMapDef(
-        colormap="b_diverging_gkr_60_10_c40",
-        lower_limit=-100,
-        upper_limit=100,
+        # colormap="b_diverging_gkr_60_10_c40",
+        colormap="b_diverging_bwr_55_98_c37",
+        lower_limit=0,
+        upper_limit=200,
+        reverse=True,
     )
-    legend = LegendDef(steps=5, decimals=0)
+    legend = LegendDef(steps=9, decimals=0)
     related_carrier = CarrierEnum.ALL
     related_balance = BalanceEnum.BALANCE
 
@@ -69,7 +71,7 @@ class AllCarriersBalanceNormalized(AbstractResultMap):
         )
 
         # Calculate balance percentage
-        return (total_supply - total_demand) / total_demand * 100
+        return total_supply / total_demand * 100
 
     @staticmethod
     def map_aggregate(var: "Var"):

--- a/hail/config/results/maps/allcarriersdemand.py
+++ b/hail/config/results/maps/allcarriersdemand.py
@@ -22,7 +22,7 @@ class AllCarriersBalanceNormalized(AbstractResultMap):
     name = "Totale energievraag"
     unit = "PJ"  # TODO: check unit
     colormap = ColorMapDef(
-        colormap="b_linear_bmy_10_95_c78",
+        colormap="b_linear_wyor_100_45_c55",
     )
     legend = LegendDef(steps=7, decimals=0)
     related_carrier = CarrierEnum.ALL

--- a/hail/config/results/maps/allcarrierssupply.py
+++ b/hail/config/results/maps/allcarrierssupply.py
@@ -23,7 +23,7 @@ class AllCarriersSupplyAbsolute(AbstractResultMap):
     unit = "PJ"  # TODO: check unit
     colormap = ColorMapDef(
         # colormap="b_linear_wyor_100_45_c55",
-        colormap="b_linear_kgy_5_95_c69",
+        colormap="b_linear_blue_95_50_c20",
     )
     legend = LegendDef(steps=7, decimals=0)
     related_carrier = CarrierEnum.ALL

--- a/hail/config/results/maps/allcarrierssupply.py
+++ b/hail/config/results/maps/allcarrierssupply.py
@@ -22,7 +22,8 @@ class AllCarriersSupplyAbsolute(AbstractResultMap):
     name = "Totale energieproductie"
     unit = "PJ"  # TODO: check unit
     colormap = ColorMapDef(
-        colormap="b_linear_wyor_100_45_c55",
+        # colormap="b_linear_wyor_100_45_c55",
+        colormap="b_linear_kgy_5_95_c69",
     )
     legend = LegendDef(steps=7, decimals=0)
     related_carrier = CarrierEnum.ALL

--- a/hail/config/results/maps/electricitybalance.py
+++ b/hail/config/results/maps/electricitybalance.py
@@ -14,14 +14,15 @@ if TYPE_CHECKING:
 class ElectricityBalanceNormalized(AbstractResultMap):
 
     key = "electricity_balance_normalized"
-    name = "Elektriciteitsbalans (percentage)"
+    name = "Elektriciteitsbalans, aanbod-vraag ratio (%)"
     unit = "%"  # TODO: make a unit Enum
     colormap = ColorMapDef(
-        colormap="b_diverging_gkr_60_10_c40",
-        lower_limit=-100,
-        upper_limit=100,
+        colormap="b_diverging_bwr_55_98_c37",
+        lower_limit=0,
+        upper_limit=200,
+        reverse=True
     )
-    legend = LegendDef(steps=5, decimals=0)
+    legend = LegendDef(steps=9, decimals=0)
     related_carrier = CarrierEnum.ELECTRICITY
     related_balance = BalanceEnum.BALANCE
 

--- a/hail/config/results/maps/electricitydemand.py
+++ b/hail/config/results/maps/electricitydemand.py
@@ -17,7 +17,7 @@ class ElectricityBalanceNormalized(AbstractResultMap):
     name = "Elektriciteitsvraag"
     unit = "PJ"  # TODO: check unit
     colormap = ColorMapDef(
-        colormap="b_linear_bmy_10_95_c78",
+        colormap="b_linear_wyor_100_45_c55",
     )
     legend = LegendDef(steps=7, decimals=0)
     related_carrier = CarrierEnum.ELECTRICITY

--- a/hail/config/results/maps/electricitysupply.py
+++ b/hail/config/results/maps/electricitysupply.py
@@ -17,7 +17,7 @@ class ElectricitySupplyAbsolute(AbstractResultMap):
     name = "Elektriciteitsproductie"
     unit = "PJ"  # TODO: check unit
     colormap = ColorMapDef(
-        colormap="b_linear_wyor_100_45_c55",
+        colormap="b_linear_blue_95_50_c20",
     )
     legend = LegendDef(steps=7, decimals=0)
     related_carrier = CarrierEnum.ELECTRICITY

--- a/hail/config/results/maps/gasbalance.py
+++ b/hail/config/results/maps/gasbalance.py
@@ -16,14 +16,15 @@ if TYPE_CHECKING:
 class GasBalanceNormalized(AbstractResultMap):
 
     key = "gas_balance_normalized"
-    name = "Gasbalans (percentage)"
+    name = "Gasbalans, aanbod-vraag ratio (%)"
     unit = "%"
     colormap = ColorMapDef(
-        colormap="b_diverging_gkr_60_10_c40",
-        lower_limit=-100,
-        upper_limit=100,
+        colormap="b_diverging_bwr_55_98_c37",
+        lower_limit=0,
+        upper_limit=200,
+        reverse=True
     )
-    legend = LegendDef(steps=5, decimals=0)
+    legend = LegendDef(steps=9, decimals=0)
     related_carrier = CarrierEnum.GAS
     related_balance = BalanceEnum.BALANCE
 

--- a/hail/config/results/maps/gasdemand.py
+++ b/hail/config/results/maps/gasdemand.py
@@ -20,7 +20,7 @@ class GasDemandAbsolute(AbstractResultMap):
     name = "Gasvraag"
     unit = "PJ"  # TODO: check unit
     colormap = ColorMapDef(
-        colormap="b_linear_bmy_10_95_c78",
+        colormap="b_linear_wyor_100_45_c55",
     )
     legend = LegendDef(steps=7, decimals=0)
     related_carrier = CarrierEnum.GAS

--- a/hail/config/results/maps/gassupply.py
+++ b/hail/config/results/maps/gassupply.py
@@ -20,7 +20,7 @@ class GasSupplyAbsolute(AbstractResultMap):
     name = "Gasproductie"
     unit = "PJ"  # TODO: check unit
     colormap = ColorMapDef(
-        colormap="b_linear_wyor_100_45_c55",
+        colormap="b_linear_blue_95_50_c20",
     )
     legend = LegendDef(steps=7, decimals=0)
     related_carrier = CarrierEnum.GAS

--- a/hail/config/results/maps/gridloaddemand.py
+++ b/hail/config/results/maps/gridloaddemand.py
@@ -20,7 +20,7 @@ class GridLoadDemand(AbstractResultMap):
     name = "Netbelasting door afname"
     unit = "%"  # TODO: make a unit Enum
     colormap = ColorMapDef(
-        colormap="b_diverging_gkr_60_10_c40",
+        colormap="b_linear_wyor_100_45_c55",
         lower_limit=0,
         upper_limit=250,
     )

--- a/hail/config/results/maps/gridloadsupply.py
+++ b/hail/config/results/maps/gridloadsupply.py
@@ -20,7 +20,7 @@ class GridLoadSupply(AbstractResultMap):
     name = "Netbelasting door invoeding"
     unit = "%"  # TODO: make a unit Enum
     colormap = ColorMapDef(
-        colormap="b_diverging_gkr_60_10_c40",
+        colormap="b_linear_blue_95_50_c20",
         lower_limit=0,
         upper_limit=250,
     )

--- a/hail/config/results/maps/heatbalance.py
+++ b/hail/config/results/maps/heatbalance.py
@@ -19,14 +19,15 @@ if TYPE_CHECKING:
 class HeatBalanceNormalized(AbstractResultMap):
 
     key = "heat_balance_normalized"
-    name = "Warmtebalans (percentage)"
+    name = "Warmtebalans, aanbod-vraag ratio (%)"
     unit = "%"
     colormap = ColorMapDef(
-        colormap="b_diverging_gkr_60_10_c40",
-        lower_limit=-100,
-        upper_limit=100,
+        colormap="b_diverging_bwr_55_98_c37",
+        lower_limit=0,
+        upper_limit=200,
+        reverse=True
     )
-    legend = LegendDef(steps=5, decimals=0)
+    legend = LegendDef(steps=9, decimals=0)
     related_carrier = CarrierEnum.HEAT
     related_balance = BalanceEnum.BALANCE
 

--- a/hail/config/results/maps/heatdemand.py
+++ b/hail/config/results/maps/heatdemand.py
@@ -22,7 +22,7 @@ class HeatDemand(AbstractResultMap):
     name = "Warmtevraag"
     unit = "PJ"  # TODO: check unit
     colormap = ColorMapDef(
-        colormap="b_linear_bmy_10_95_c78",
+        colormap="b_linear_wyor_100_45_c55",
     )
     legend = LegendDef(steps=7, decimals=0)
     related_carrier = CarrierEnum.HEAT

--- a/hail/config/results/maps/heatsupply.py
+++ b/hail/config/results/maps/heatsupply.py
@@ -19,7 +19,7 @@ class HeatSupply(AbstractResultMap):
     name = "Warmteproductie"
     unit = "PJ"  # TODO: check unit
     colormap = ColorMapDef(
-        colormap="b_linear_wyor_100_45_c55",
+        colormap="b_linear_blue_95_50_c20",
     )
     legend = LegendDef(steps=7, decimals=0)
     related_carrier = CarrierEnum.HEAT

--- a/hail/hail/models/calculate.py
+++ b/hail/hail/models/calculate.py
@@ -55,6 +55,8 @@ class LegendDef(BaseModel):
 
 class ColorMapDef(BaseModel):
     colormap: str
+    reverse: bool = False
+    # if True, the colormap will be reversed
     lower_limit: Optional[float | int] = None
     # if None, the minimum value of the data is used
     upper_limit: Optional[float | int] = None
@@ -70,6 +72,7 @@ class ColorMapDef(BaseModel):
             cmap_name=self.colormap,
             vmin=self.lower_limit,
             vmax=self.upper_limit,
+            reverse=self.reverse,
         )
 
     def model_post_init(self, __context: Any) -> None:

--- a/hail/hail/util/__init__.py
+++ b/hail/hail/util/__init__.py
@@ -126,6 +126,7 @@ def get_color(
     cmap_name="b_diverging_protanopic_deuteranopic_bwy_60_95_c32",
     vmin=0,
     vmax=100,
+    reverse=False,
 ):
     if value is None:
         logging.debug("[colormap]: Value is None, returning white")
@@ -144,6 +145,11 @@ def get_color(
 
     norm_value = normalize(value, vmin, vmax)
     cmap = getattr(cc, cmap_name)
+    
+    # Reverse the colormap if requested
+    if reverse:
+        norm_value = 255 - norm_value
+    
     color = cmap[norm_value]
 
     return color


### PR DESCRIPTION
- Added a 'reverse' functionality for creating color scales the other way around
- Changed the definition of energy balances to become more intuitive, it is now supply/demand as a ratio
- Changed colormaps. There is expliciet distinction in colors between the balance, supply and demand maps. Different carriers have the same color (so you have to look at the UI button to know which carrier you are looking at). I found this to be the most intuitive. It keeps color scales to a total of 3 different ones. With logical color scale change when looking at a different "concept".
- Use 9 legend entries which makes it nicely centered around 0