### PR TITLE
change type comment to prevent blocking build

### DIFF
--- a/app/frontend/components/EnergyBalance/GeoJsonLabel.tsx
+++ b/app/frontend/components/EnergyBalance/GeoJsonLabel.tsx
@@ -123,7 +123,7 @@ const GeoJsonLabel = ({
         <Marker
             key={`label-${feature.properties.gid}`}
             position={[center.lng, center.lat] as L.LatLngExpression}
-            // @ts-ignore - Leaflet icon type compatibility
+            // @ts-expect-error - Leaflet icon type compatibility
             icon={labelIcon}
         />
     );


### PR DESCRIPTION
The GeoJsonLabel had a typescript comment that was giving an error. This blocked the build of the frontend. 
The comment is changed now and it should build correctly (it builds well locally). 