### PR TITLE
Only request curves when actually needed

### DIFF
--- a/hail/app_functions.py
+++ b/hail/app_functions.py
@@ -65,8 +65,15 @@ async def initial_context_call(
     # TODO: make sure this logic is not flawed due to the state of the ETM scenarios (e.g. convergence)
     # TODO: In principle, we should always hit cache for non-updated scenario's if we solely base this on area codes
     # E.g., hash the input differently for scenarios without user_values (request.UserSettings.<con/sec>Developments is None)
+    # Only fetch curve gqueries when the curve graph is requested
+    needs_curves = (
+        request.viewSettings.graphType is not None
+        and request.viewSettings.graphType.value == "energybalance_curve"
+    )
+    gqueries = accessed_attributes.gqueries_all if needs_curves else accessed_attributes.gqueries
+
     return await client.connect(
-        gqueries=accessed_attributes.gqueries,
+        gqueries=gqueries,
         inputs=accessed_attributes.inputs,
         ui=accessed_attributes.ui,
     )
@@ -101,8 +108,14 @@ async def update_context(
         redis_client=redis_client,
     )
 
+    needs_curves = (
+        request.viewSettings.graphType is not None
+        and request.viewSettings.graphType.value == "energybalance_curve"
+    )
+    gqueries = accessed_attributes.gqueries_all if needs_curves else accessed_attributes.gqueries
+
     updated_context = await updated_client.connect(
-        gqueries=accessed_attributes.gqueries,
+        gqueries=gqueries,
         inputs=accessed_attributes.inputs,
         ui=accessed_attributes.ui,
     )
@@ -329,7 +342,7 @@ async def get_curve_graph(
     )
 
     context = await client.connect(
-        gqueries=accessed_attributes.gqueries,
+        gqueries=accessed_attributes.gqueries_all,
         inputs=accessed_attributes.inputs,
         ui=accessed_attributes.ui,
     )

--- a/hail/hail/models/calculate.py
+++ b/hail/hail/models/calculate.py
@@ -217,7 +217,7 @@ class GraphCurveElement(BaseModel, arbitrary_types_allowed=True):
     group: str
     demandSupply: str
     color: str
-    value: Curve
+    value: list | Curve
 
     def filter_on_index(self, index: int) -> GraphCurveElement:
         assert isinstance(

--- a/hail/hail/models/configuration.py
+++ b/hail/hail/models/configuration.py
@@ -139,11 +139,13 @@ class AccessedAttributes(BaseModel):
     _ui: set = set()
     _inputs: set = set()
     _gqueries: set = set()
+    _gqueries_curve: set = set()
 
     def __add__(self, other: AccessedAttributes) -> AccessedAttributes:
         self._ui.update(other._ui)
         self._inputs.update(other._inputs)
         self._gqueries.update(other._gqueries)
+        self._gqueries_curve.update(other._gqueries_curve)
         return self
 
     @property
@@ -158,15 +160,26 @@ class AccessedAttributes(BaseModel):
 
     @property
     def gqueries(self):
-        """Sorted list of accessed gquery attributes, important for consistent cache key generation"""
+        """Sorted list of accessed gquery attributes (excluding curve gqueries)"""
         return sorted(list(self._gqueries))
 
     @property
+    def gqueries_curve(self):
+        """Sorted list of accessed curve gquery attributes"""
+        return sorted(list(self._gqueries_curve))
+
+    @property
+    def gqueries_all(self):
+        """Sorted list of all accessed gquery attributes (base + curve)"""
+        return sorted(list(self._gqueries | self._gqueries_curve))
+
+    @property
     def private_model_fields_names(self):
+        """Used by the AST visitor to match attribute patterns like var.gqueries.xxx"""
         return ["_ui", "_inputs", "_gqueries"]
 
     def __str__(self):
-        return f"AccessedAttributes(ui={self.ui}, inputs={self.inputs}, gqueries={self.gqueries})"
+        return f"AccessedAttributes(ui={self.ui}, inputs={self.inputs}, gqueries={self.gqueries}, gqueries_curve={self.gqueries_curve})"
 
     def __repr__(self):
         return str(self)

--- a/hail/hail/parse.py
+++ b/hail/hail/parse.py
@@ -67,10 +67,22 @@ def find_accessed_attributes(file_path, class_name: str = "var") -> AccessedAttr
     return finder.accessed_attributes
 
 
+def _is_curve_graph_file(file_path: Path) -> bool:
+    """Check if a file defines a curve graph class (subclass of AbstractResultCurveGraph)."""
+    with open(file_path, "r") as f:
+        content = f.read()
+    return "AbstractResultCurveGraph" in content
+
+
 def find_all_accessed_attributes(config_folder: Path) -> AccessedAttributes:
     accessed_attributes = AccessedAttributes()
     for file in config_folder.glob("**/*.py"):
-        accessed_attributes += find_accessed_attributes(file, "var")
+        file_attrs = find_accessed_attributes(file, "var")
+        if _is_curve_graph_file(file):
+            # Route gqueries from curve graph files into _gqueries_curve
+            accessed_attributes._gqueries_curve.update(file_attrs._gqueries)
+            file_attrs._gqueries = set()
+        accessed_attributes += file_attrs
     return accessed_attributes
 
 


### PR DESCRIPTION
DRAFT.

Attempt at reducing fetch times by being selective about what to fetch

[configuration.py] — Added _gqueries_curve set to AccessedAttributes, plus gqueries_curve and gqueries_all properties. The __add__ merge also handles the new field.

[parse.py] — Added _is_curve_graph_file() helper that checks if a file contains AbstractResultCurveGraph. In find_all_accessed_attributes, curve graph files have their gqueries routed to _gqueries_curve instead of _gqueries.

[app_functions.py] — In initial_context_call and update_context, the gqueries set is now chosen based on request.viewSettings.graphType: only when "energybalance_curve" is requested are curve gqueries included (via gqueries_all). The dedicated curve endpoints (get_curve_toplevel, get_curve_graph) use gqueries_all since they always need curve data.

The net effect: requests with graphType: 'energybalance_bar' or null (the vast majority) will no longer fetch ~70 curve gqueries returning 8760 hourly values each, which should bring response times back to ~200ms.