### PR TITLE
Update graph energy profile

### DIFF
--- a/app/frontend/components/Graph/EnergyBalanceGraph/EnergyBalanceGraph.tsx
+++ b/app/frontend/components/Graph/EnergyBalanceGraph/EnergyBalanceGraph.tsx
@@ -73,7 +73,10 @@ export default function EnergyBalanceGraph({ data }: GraphProps) {
                             selectedItems={selectedSectors}
                             onToggleItem={toggleSector}
                             legendData={legendData}
-                            reverseOrder={true}
+                            reverseOrder={{
+                                "Vraag": true,
+                                "Aanbod": true
+                            }}
                         />
                     ) : (
                         <FilterSection
@@ -82,7 +85,10 @@ export default function EnergyBalanceGraph({ data }: GraphProps) {
                             selectedItems={selectedDragers}
                             onToggleItem={toggleDrager}
                             legendData={legendData}
-                            reverseOrder={true}
+                            reverseOrder={{
+                                "Vraag": true,
+                                "Aanbod": true
+                            }}
                         />
                     )}
                 </div>

--- a/app/frontend/components/Graph/EnergyBalanceGraph/EnergyBalanceGraph.tsx
+++ b/app/frontend/components/Graph/EnergyBalanceGraph/EnergyBalanceGraph.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { GraphProps } from '@/types/components/Graph';
 import { useEnergyBalanceData } from '@/hooks/useEnergyBalanceData';
 import RadioOption from '../../ui/radioButtonOption';
-import FilterSection from './FilterSection';
+import FilterSection from '../FilterSection';
 import EnergyBalanceChart from './EnergyBalanceChart';
 import { ViewMode } from '@/types/components/Graph';
 
@@ -73,6 +73,7 @@ export default function EnergyBalanceGraph({ data }: GraphProps) {
                             selectedItems={selectedSectors}
                             onToggleItem={toggleSector}
                             legendData={legendData}
+                            reverseOrder={true}
                         />
                     ) : (
                         <FilterSection
@@ -81,6 +82,7 @@ export default function EnergyBalanceGraph({ data }: GraphProps) {
                             selectedItems={selectedDragers}
                             onToggleItem={toggleDrager}
                             legendData={legendData}
+                            reverseOrder={true}
                         />
                     )}
                 </div>

--- a/app/frontend/components/Graph/EnergyProfileGraph/EnergyProfileChart.tsx
+++ b/app/frontend/components/Graph/EnergyProfileGraph/EnergyProfileChart.tsx
@@ -1,0 +1,105 @@
+import { ComposedChart, Area, Line, XAxis, YAxis, ResponsiveContainer, CartesianGrid, Tooltip, ReferenceLine } from 'recharts';
+import CustomYAxisLabel from './CustomYAxisLabel';
+import { EnergyProfileChartProps } from '@/types/components/EnergyProfileGraph';
+
+
+export default function EnergyProfileChart({
+    chartData,
+    metadata,
+    dataKeys,
+    hasBasislast,
+    colors
+}: EnergyProfileChartProps) {
+    const CustomTooltip = ({ active, payload, label }: any) => {
+        if (active && payload && payload.length) {
+            // Group payload by demandSupply type
+            const groupedPayload = payload.reduce((acc: any, entry: any) => {
+                const demandSupply = metadata?.properties?.[entry.dataKey]?.demandSupply || '';
+                if (!acc[demandSupply]) {
+                    acc[demandSupply] = [];
+                }
+                acc[demandSupply].push(entry);
+                return acc;
+            }, {});
+            
+            return (
+                <div className="bg-white p-3 border border-gray-300 rounded shadow-lg">
+                    <p className="font-semibold">{label}</p>
+                    {/* Show Aanbod first */}
+                    {groupedPayload['Aanbod'] && (
+                        <>
+                            <p className="font-semibold text-sm mt-2">Aanbod</p>
+                            {groupedPayload['Aanbod'].map((entry: any, index: number) => (
+                                <p key={`aanbod-${index}`} className="ml-2">
+                                    {`${entry.dataKey}: ${entry.value?.toFixed(2) || 0} ${metadata?.unit || ''}`}
+                                </p>
+                            ))}
+                        </>
+                    )}
+                    {/* Then show Vraag */}
+                    {groupedPayload['Vraag'] && (
+                        <>
+                            <p className="font-semibold text-sm mt-2">Vraag</p>
+                            {groupedPayload['Vraag'].map((entry: any, index: number) => (
+                                <p key={`vraag-${index}`} className="ml-2">
+                                    {`${entry.dataKey}: ${entry.value?.toFixed(2) || 0} ${metadata?.unit || ''}`}
+                                </p>
+                            ))}
+                        </>
+                    )}
+                </div>
+            );
+        }
+        return null;
+    };
+
+    return (
+        <ResponsiveContainer width="100%" height="100%">
+            <ComposedChart
+                data={chartData}
+                margin={{
+                    top: 20,
+                    right: 30,
+                    left: 20,
+                    bottom: 5,
+                }}
+            >
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis 
+                    dataKey="name" 
+                    interval={Math.floor(chartData.length / 12)} // Show every Nth tick for ~12 labels
+                    tick={{ fontSize: 14 }}
+                />  
+                <YAxis label={(props: any) => <CustomYAxisLabel {...props} metadata={metadata} />}  tick={{ fontSize: 14 }} />
+                <Tooltip content={<CustomTooltip />} />
+                <ReferenceLine y={0} stroke="#666" strokeWidth={1} />
+              
+                {dataKeys.map((key, index) => {
+                    const demandSupply = metadata?.properties?.[key]?.demandSupply;
+                    const stackId = demandSupply === 'Vraag' ? 'demand' : 'supply';
+                    
+                    return (
+                        <Area 
+                            key={key}
+                            type="monotone" 
+                            dataKey={key} 
+                            stackId={stackId}
+                            stroke={metadata?.properties?.[key]?.color || colors[index % colors.length]} 
+                            fill={metadata?.properties?.[key]?.color || colors[index % colors.length]} 
+                        />
+                    );
+                })}
+                {hasBasislast && (
+                    <Line
+                        type="monotone"
+                        dataKey="Basislast elektriciteitsvraag"
+                        stroke={metadata?.properties?.['Basislast elektriciteitsvraag']?.color || '#ff0000'}
+                        strokeWidth={3}
+                        strokeDasharray="3 3"
+                        dot={false}
+                    />
+                )}
+            </ComposedChart>
+        </ResponsiveContainer>
+    );
+}

--- a/app/frontend/components/Graph/EnergyProfileGraph/EnergyProfileChart.tsx
+++ b/app/frontend/components/Graph/EnergyProfileGraph/EnergyProfileChart.tsx
@@ -125,37 +125,9 @@ export default function EnergyProfileChart({
 
     return (
         <div className="w-full h-full min-h-[400px] flex flex-col">
-            <div className="flex justify-between items-center mb-2 flex-shrink-0">
-                <span className="text-sm text-gray-600">
-                    {isZoomed && selectedMonthRange ? (
-                        (() => {
-                            const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-                            const startMonth = months[selectedMonthRange.startMonth];
-                            const endMonth = months[selectedMonthRange.endMonth];
-                            return selectedMonthRange.startMonth === selectedMonthRange.endMonth ? 
-                                `Showing ${startMonth}` : 
-                                `Showing ${startMonth} - ${endMonth}`;
-                        })()
-                    ) : 
-                        'Showing full year'
-                    }
-                </span>
-                <div className="flex gap-2 items-center">
-                    {isZoomed && (
-                        <button 
-                            onClick={resetZoom}
-                            className="px-3 py-1 text-sm bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors"
-                        >
-                            Reset Zoom
-                        </button>
-                    )}
-                    <span className="text-xs text-gray-500">
-                        {isZoomed ? 'Drag handles to adjust or click Reset' : 'Drag brush handles to zoom'}
-                    </span>
-                </div>
-            </div>
+           
             
-            <div className="flex-1 min-h-[350px]">
+            <div className="flex-1 min-h-[350px] max-h-[600px]">
                 <ResponsiveContainer width="100%" height="100%">
                     <ComposedChart
                         data={displayData}
@@ -208,12 +180,11 @@ export default function EnergyProfileChart({
                             data={monthlyBrushData}
                             dataKey="name"
                             height={60}
-                            stroke="#2563eb"
-                            fill="rgba(37, 99, 235, 0.1)"
+                            stroke="#003461"
+                            fill="rgba(0, 52, 97, 0.2)"
                             onChange={handleBrushChange}
                             startIndex={selectedMonthRange?.startMonth ?? undefined}
                             endIndex={selectedMonthRange?.endMonth ?? undefined}
-                            tick={{ fontSize: 12 }}
                             tickFormatter={(value) => value} // Shows month names directly
                             travellerWidth={8}
                         />

--- a/app/frontend/components/Graph/EnergyProfileGraph/EnergyProfileChart.tsx
+++ b/app/frontend/components/Graph/EnergyProfileGraph/EnergyProfileChart.tsx
@@ -1,4 +1,6 @@
-import { ComposedChart, Area, Line, XAxis, YAxis, ResponsiveContainer, CartesianGrid, Tooltip, ReferenceLine } from 'recharts';
+import { ComposedChart, Area, Line, XAxis, YAxis, ResponsiveContainer, CartesianGrid, Tooltip, ReferenceLine, Brush } from 'recharts';
+import { useState, useMemo, useCallback } from 'react';
+import React from 'react';
 import CustomYAxisLabel from './CustomYAxisLabel';
 import { EnergyProfileChartProps } from '@/types/components/EnergyProfileGraph';
 
@@ -10,7 +12,75 @@ export default function EnergyProfileChart({
     hasBasislast,
     colors
 }: EnergyProfileChartProps) {
-    const CustomTooltip = ({ active, payload, label }: any) => {
+    // State for brush-based zooming with monthly segments
+    const [selectedMonthRange, setSelectedMonthRange] = useState<{ startMonth: number; endMonth: number } | null>(null);
+    
+    const isZoomed = selectedMonthRange !== null;
+
+    // Create 12-month brush data for better performance and UX
+    const monthlyBrushData = useMemo(() => {
+        const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+        return months.map((month, index) => ({
+            name: month,
+            month: index,
+            // Add a representative value for visual feedback in brush
+            value: index + 1 
+        }));
+    }, []);
+
+    // Calculate actual data indices from month selection
+    const actualDataIndices = useMemo(() => {
+        if (!selectedMonthRange) return null;
+        
+        const pointsPerMonth = Math.floor(chartData.length / 12);
+        const startIndex = selectedMonthRange.startMonth * pointsPerMonth;
+        const endIndex = selectedMonthRange.endMonth === 11 
+            ? chartData.length - 1 
+            : (selectedMonthRange.endMonth + 1) * pointsPerMonth - 1;
+            
+        return { startIndex, endIndex };
+    }, [selectedMonthRange, chartData.length]);
+
+    // Handle brush change - map from month indices to actual data
+    const handleBrushChange = useCallback((e: any) => {
+        if (e && 
+            typeof e.startIndex === 'number' && 
+            typeof e.endIndex === 'number' && 
+            e.startIndex >= 0 && 
+            e.endIndex >= 0 &&
+            e.startIndex <= 11 &&
+            e.endIndex <= 11 &&
+            e.startIndex <= e.endIndex) {
+                
+            console.log('Month range selected:', { start: e.startIndex, end: e.endIndex });
+            setSelectedMonthRange({ 
+                startMonth: e.startIndex, 
+                endMonth: e.endIndex 
+            });
+        } else {
+            console.log('Clearing month selection');
+            setSelectedMonthRange(null);
+        }
+    }, []);
+
+    // Reset zoom function
+    const resetZoom = useCallback(() => {
+        setSelectedMonthRange(null);
+    }, []);
+
+    // Calculate display data based on month selection
+    const displayData = useMemo(() => {
+        if (!actualDataIndices) return chartData;
+        
+        return chartData.slice(actualDataIndices.startIndex, actualDataIndices.endIndex + 1);
+    }, [chartData, actualDataIndices]);
+
+    // Calculate X-axis interval for better performance
+    const xAxisInterval = useMemo(() => {
+        return Math.max(1, Math.floor(displayData.length / 12));
+    }, [displayData.length]);
+
+    const CustomTooltip = useCallback(({ active, payload, label }: any) => {
         if (active && payload && payload.length) {
             // Group payload by demandSupply type
             const groupedPayload = payload.reduce((acc: any, entry: any) => {
@@ -51,55 +121,105 @@ export default function EnergyProfileChart({
             );
         }
         return null;
-    };
+    }, [metadata?.unit]);
 
     return (
-        <ResponsiveContainer width="100%" height="100%">
-            <ComposedChart
-                data={chartData}
-                margin={{
-                    top: 20,
-                    right: 30,
-                    left: 20,
-                    bottom: 5,
-                }}
-            >
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis 
-                    dataKey="name" 
-                    interval={Math.floor(chartData.length / 12)} // Show every Nth tick for ~12 labels
-                    tick={{ fontSize: 14 }}
-                />  
-                <YAxis label={(props: any) => <CustomYAxisLabel {...props} metadata={metadata} />}  tick={{ fontSize: 14 }} />
-                <Tooltip content={<CustomTooltip />} />
-                <ReferenceLine y={0} stroke="#666" strokeWidth={1} />
-              
-                {dataKeys.map((key, index) => {
-                    const demandSupply = metadata?.properties?.[key]?.demandSupply;
-                    const stackId = demandSupply === 'Vraag' ? 'demand' : 'supply';
+        <div className="w-full h-full min-h-[400px] flex flex-col">
+            <div className="flex justify-between items-center mb-2 flex-shrink-0">
+                <span className="text-sm text-gray-600">
+                    {isZoomed && selectedMonthRange ? (
+                        (() => {
+                            const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+                            const startMonth = months[selectedMonthRange.startMonth];
+                            const endMonth = months[selectedMonthRange.endMonth];
+                            return selectedMonthRange.startMonth === selectedMonthRange.endMonth ? 
+                                `Showing ${startMonth}` : 
+                                `Showing ${startMonth} - ${endMonth}`;
+                        })()
+                    ) : 
+                        'Showing full year'
+                    }
+                </span>
+                <div className="flex gap-2 items-center">
+                    {isZoomed && (
+                        <button 
+                            onClick={resetZoom}
+                            className="px-3 py-1 text-sm bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors"
+                        >
+                            Reset Zoom
+                        </button>
+                    )}
+                    <span className="text-xs text-gray-500">
+                        {isZoomed ? 'Drag handles to adjust or click Reset' : 'Drag brush handles to zoom'}
+                    </span>
+                </div>
+            </div>
+            
+            <div className="flex-1 min-h-[350px]">
+                <ResponsiveContainer width="100%" height="100%">
+                    <ComposedChart
+                        data={displayData}
+                        margin={{
+                            top: 20,
+                            right: 30,
+                            left: 20,
+                            bottom: 60, // Space for brush component
+                        }}
+                    >
+                        <CartesianGrid strokeDasharray="3 3" />
+                        <XAxis 
+                            dataKey="name" 
+                            interval={xAxisInterval}
+                            tick={{ fontSize: 14 }}
+                        />  
+                        <YAxis label={(props: any) => <CustomYAxisLabel {...props} metadata={metadata} />}  tick={{ fontSize: 14 }} />
+                        <Tooltip content={<CustomTooltip />} />
+                        <ReferenceLine y={0} stroke="#666" strokeWidth={1} />
+                        
+                        {dataKeys.map((key, index) => {
+                            const demandSupply = metadata?.properties?.[key]?.demandSupply;
+                            const stackId = demandSupply === 'Vraag' ? 'demand' : 'supply';
+                            
+                            return (
+                                <Area 
+                                    key={key}
+                                    type="monotone" 
+                                    dataKey={key} 
+                                    stackId={stackId}
+                                    stroke={metadata?.properties?.[key]?.color || colors[index % colors.length]} 
+                                    fill={metadata?.properties?.[key]?.color || colors[index % colors.length]} 
+                                />
+                            );
+                        })}
+                        {hasBasislast && (
+                            <Line
+                                type="monotone"
+                                dataKey="Basislast elektriciteitsvraag"
+                                stroke={metadata?.properties?.['Basislast elektriciteitsvraag']?.color || '#ff0000'}
+                                strokeWidth={3}
+                                strokeDasharray="3 3"
+                                dot={false}
+                            />
+                        )}
                     
-                    return (
-                        <Area 
-                            key={key}
-                            type="monotone" 
-                            dataKey={key} 
-                            stackId={stackId}
-                            stroke={metadata?.properties?.[key]?.color || colors[index % colors.length]} 
-                            fill={metadata?.properties?.[key]?.color || colors[index % colors.length]} 
+                        {/* Monthly brush with 12 segments for yearly data */}
+                        <Brush 
+                            key={`monthly-brush-${chartData.length}`}
+                            data={monthlyBrushData}
+                            dataKey="name"
+                            height={60}
+                            stroke="#2563eb"
+                            fill="rgba(37, 99, 235, 0.1)"
+                            onChange={handleBrushChange}
+                            startIndex={selectedMonthRange?.startMonth ?? undefined}
+                            endIndex={selectedMonthRange?.endMonth ?? undefined}
+                            tick={{ fontSize: 12 }}
+                            tickFormatter={(value) => value} // Shows month names directly
+                            travellerWidth={8}
                         />
-                    );
-                })}
-                {hasBasislast && (
-                    <Line
-                        type="monotone"
-                        dataKey="Basislast elektriciteitsvraag"
-                        stroke={metadata?.properties?.['Basislast elektriciteitsvraag']?.color || '#ff0000'}
-                        strokeWidth={3}
-                        strokeDasharray="3 3"
-                        dot={false}
-                    />
-                )}
-            </ComposedChart>
-        </ResponsiveContainer>
+                    </ComposedChart>
+                </ResponsiveContainer>
+            </div>
+        </div>
     );
 }

--- a/app/frontend/components/Graph/EnergyProfileGraph/EnergyProfileGraph.tsx
+++ b/app/frontend/components/Graph/EnergyProfileGraph/EnergyProfileGraph.tsx
@@ -1,4 +1,5 @@
 
+import React, { useState } from 'react';
 import { ComposedChart, Area, Line, XAxis, YAxis, ResponsiveContainer, CartesianGrid, Tooltip, ReferenceLine } from 'recharts';
 import Loader from '@/components/Loader/Loader';
 import { EnergyProfileGraphProps } from '@/types/components/EnergyProfileGraph';
@@ -10,6 +11,25 @@ export default function EnergyProfileGraph({
     enabled = true 
 }: EnergyProfileGraphProps) {
     const { data, metadata, loading, error } = useEnergyProfileData({ enabled });
+
+    // State for selected items (initially empty, will be set when data loads)
+    const [selectedItems, setSelectedItems] = useState<string[]>([]);
+
+    // Update selectedItems when data changes
+    React.useEffect(() => {
+        if (data.length > 0) {
+            const newDataKeys = Object.keys(data[0]).filter(key => key !== 'name');
+            setSelectedItems(newDataKeys);
+        }
+    }, [data]);
+
+    const toggleItem = (item: string) => {
+        setSelectedItems(prev => 
+            prev.includes(item)
+                ? prev.filter(i => i !== item)
+                : [...prev, item]
+        );
+    };
 
     const CustomTooltip = ({ active, payload, label }: any) => {
         if (active && payload && payload.length) {
@@ -71,9 +91,9 @@ export default function EnergyProfileGraph({
         ? Object.keys(chartData[0]).filter(key => key !== 'name')
         : [];
     
-    // Separate 'Basislast elektriciteit' from other keys
-    const dataKeys = allDataKeys.filter(key => key !== 'Basislast elektriciteitsvraag');
-    const hasBasislast = allDataKeys.includes('Basislast elektriciteitsvraag');
+    // Filter data keys based on selected items and separate 'Basislast elektriciteit' from other keys
+    const dataKeys = allDataKeys.filter(key => key !== 'Basislast elektriciteitsvraag' && selectedItems.includes(key));
+    const hasBasislast = allDataKeys.includes('Basislast elektriciteitsvraag') && selectedItems.includes('Basislast elektriciteitsvraag');
     return (
         <div className="flex flex-col h-[550px] flex-1">
             <div className="text-left p-8 flex-1 flex flex-col">
@@ -113,8 +133,8 @@ export default function EnergyProfileGraph({
                                     }));
                                 return [...aanbodItems, ...vraagItems];
                             })() : []}
-                            selectedItems={dataKeys}
-                            onToggleItem={() => {}} // No toggle functionality for now
+                            selectedItems={selectedItems}
+                            onToggleItem={toggleItem} // Toggle functionality implemented
                             legendData={metadata ? Object.fromEntries(Object.entries(metadata.properties).map(([key, value], index) => [key, value.color || colors[index % colors.length]])) : {}}
                             reverseOrder={false}
                         />

--- a/app/frontend/components/Graph/EnergyProfileGraph/EnergyProfileGraph.tsx
+++ b/app/frontend/components/Graph/EnergyProfileGraph/EnergyProfileGraph.tsx
@@ -4,11 +4,55 @@ import Loader from '@/components/Loader/Loader';
 import { EnergyProfileGraphProps } from '@/types/components/EnergyProfileGraph';
 import CustomYAxisLabel from './CustomYAxisLabel';
 import { useEnergyProfileData } from '@/hooks/useEnergyProfileData';
+import FilterSection from '../FilterSection';
 
 export default function EnergyProfileGraph({ 
     enabled = true 
 }: EnergyProfileGraphProps) {
     const { data, metadata, loading, error } = useEnergyProfileData({ enabled });
+
+    const CustomTooltip = ({ active, payload, label }: any) => {
+        if (active && payload && payload.length) {
+            // Group payload by demandSupply type
+            const groupedPayload = payload.reduce((acc: any, entry: any) => {
+                const demandSupply = metadata?.properties?.[entry.dataKey]?.demandSupply || '';
+                if (!acc[demandSupply]) {
+                    acc[demandSupply] = [];
+                }
+                acc[demandSupply].push(entry);
+                return acc;
+            }, {});
+            
+            return (
+                <div className="bg-white p-3 border border-gray-300 rounded shadow-lg">
+                    <p className="font-medium">{label}</p>
+                    {/* Show Aanbod first */}
+                    {groupedPayload['Aanbod'] && (
+                        <>
+                            <p className="font-medium text-sm mt-2">Aanbod</p>
+                            {groupedPayload['Aanbod'].map((entry: any, index: number) => (
+                                <p key={`aanbod-${index}`} className="ml-2">
+                                    {`${entry.dataKey}: ${entry.value?.toFixed(2) || 0} ${metadata?.unit || ''}`}
+                                </p>
+                            ))}
+                        </>
+                    )}
+                    {/* Then show Vraag */}
+                    {groupedPayload['Vraag'] && (
+                        <>
+                            <p className="font-medium text-sm mt-2">Vraag</p>
+                            {groupedPayload['Vraag'].map((entry: any, index: number) => (
+                                <p key={`vraag-${index}`} className="ml-2">
+                                    {`${entry.dataKey}: ${entry.value?.toFixed(2) || 0} ${metadata?.unit || ''}`}
+                                </p>
+                            ))}
+                        </>
+                    )}
+                </div>
+            );
+        }
+        return null;
+    };
 
 
     const chartData = data.length > 0 ? data : [];
@@ -49,6 +93,32 @@ export default function EnergyProfileGraph({
                 )}
                 
                 {!loading && !error && (
+                  <div className="flex flex-col md:flex-row flex-1 min-h-[300px] max-h-[110%]">
+              <div className="min-w-[200px] max-w-[250px] pr-4">
+                        <FilterSection
+                            title="Selecteer energieprofielen"
+                            items={metadata ? (() => {
+                                const entries = Object.entries(metadata.properties);
+                                const aanbodItems = entries
+                                    .filter(([key, value]) => value.demandSupply === 'Aanbod')
+                                    .map(([key, value]) => ({
+                                        name: key,
+                                        demandSupply: value.demandSupply,
+                                    }));
+                                const vraagItems = entries
+                                    .filter(([key, value]) => value.demandSupply === 'Vraag')
+                                    .map(([key, value]) => ({
+                                        name: key,
+                                        demandSupply: value.demandSupply,
+                                    }));
+                                return [...aanbodItems, ...vraagItems];
+                            })() : []}
+                            selectedItems={dataKeys}
+                            onToggleItem={() => {}} // No toggle functionality for now
+                            legendData={metadata ? Object.fromEntries(Object.entries(metadata.properties).map(([key, value], index) => [key, value.color || colors[index % colors.length]])) : {}}
+                            reverseOrder={false}
+                        />
+                    </div>
                     <div className="flex-1 min-h-0">
                         <ResponsiveContainer width="100%" height="100%">
                             <ComposedChart
@@ -67,7 +137,7 @@ export default function EnergyProfileGraph({
                                     tick={{ fontSize: 14 }}
                                 />  
                                 <YAxis label={(props: any) => <CustomYAxisLabel {...props} metadata={metadata} />}  tick={{ fontSize: 14 }} />
-                                <Tooltip />
+                                <Tooltip content={<CustomTooltip />} />
                                 <ReferenceLine y={0} stroke="#666" strokeWidth={1} />
                               
                                 {dataKeys.map((key, index) => {
@@ -98,6 +168,7 @@ export default function EnergyProfileGraph({
                             </ComposedChart>
                         </ResponsiveContainer>
                     </div>
+                     </div>
                 )}
             </div>
         </div>

--- a/app/frontend/components/Graph/EnergyProfileGraph/EnergyProfileGraph.tsx
+++ b/app/frontend/components/Graph/EnergyProfileGraph/EnergyProfileGraph.tsx
@@ -92,7 +92,10 @@ export default function EnergyProfileGraph({
                             selectedItems={selectedItems}
                             onToggleItem={toggleItem} // Toggle functionality implemented
                             legendData={metadata ? Object.fromEntries(Object.entries(metadata.properties).map(([key, value], index) => [key, value.color || colors[index % colors.length]])) : {}}
-                            reverseOrder={false}
+                            reverseOrder={{
+                                "Vraag": false,
+                                "Aanbod": true,
+                            }}
                         />
                     </div>
                     <div className="flex-1 min-h-0">

--- a/app/frontend/components/Graph/EnergyProfileGraph/EnergyProfileGraph.tsx
+++ b/app/frontend/components/Graph/EnergyProfileGraph/EnergyProfileGraph.tsx
@@ -1,11 +1,11 @@
 
 import React, { useState } from 'react';
-import { ComposedChart, Area, Line, XAxis, YAxis, ResponsiveContainer, CartesianGrid, Tooltip, ReferenceLine } from 'recharts';
 import Loader from '@/components/Loader/Loader';
 import { EnergyProfileGraphProps } from '@/types/components/EnergyProfileGraph';
-import CustomYAxisLabel from './CustomYAxisLabel';
 import { useEnergyProfileData } from '@/hooks/useEnergyProfileData';
 import FilterSection from '../FilterSection';
+import EnergyProfileChart from './EnergyProfileChart';
+import { GraphDataPoint } from '@/types/components/Graph';
 
 export default function EnergyProfileGraph({ 
     enabled = true 
@@ -31,58 +31,14 @@ export default function EnergyProfileGraph({
         );
     };
 
-    const CustomTooltip = ({ active, payload, label }: any) => {
-        if (active && payload && payload.length) {
-            // Group payload by demandSupply type
-            const groupedPayload = payload.reduce((acc: any, entry: any) => {
-                const demandSupply = metadata?.properties?.[entry.dataKey]?.demandSupply || '';
-                if (!acc[demandSupply]) {
-                    acc[demandSupply] = [];
-                }
-                acc[demandSupply].push(entry);
-                return acc;
-            }, {});
-            
-            return (
-                <div className="bg-white p-3 border border-gray-300 rounded shadow-lg">
-                    <p className="font-medium">{label}</p>
-                    {/* Show Aanbod first */}
-                    {groupedPayload['Aanbod'] && (
-                        <>
-                            <p className="font-medium text-sm mt-2">Aanbod</p>
-                            {groupedPayload['Aanbod'].map((entry: any, index: number) => (
-                                <p key={`aanbod-${index}`} className="ml-2">
-                                    {`${entry.dataKey}: ${entry.value?.toFixed(2) || 0} ${metadata?.unit || ''}`}
-                                </p>
-                            ))}
-                        </>
-                    )}
-                    {/* Then show Vraag */}
-                    {groupedPayload['Vraag'] && (
-                        <>
-                            <p className="font-medium text-sm mt-2">Vraag</p>
-                            {groupedPayload['Vraag'].map((entry: any, index: number) => (
-                                <p key={`vraag-${index}`} className="ml-2">
-                                    {`${entry.dataKey}: ${entry.value?.toFixed(2) || 0} ${metadata?.unit || ''}`}
-                                </p>
-                            ))}
-                        </>
-                    )}
-                </div>
-            );
-        }
-        return null;
-    };
-
-
     const chartData = data.length > 0 ? data : [];
     const colors = ['#8884d8', '#82ca9d', '#ffc658', '#ff7c7c', '#8dd1e1'];
     
     // Transform data to include proper x-axis labels from metadata
-    const finalChartData = chartData.map((dataPoint, index) => {
+    const finalChartData: GraphDataPoint[] = chartData.map((dataPoint, index) => {
         return {
             ...dataPoint,
-            name: metadata?.xTickLabels?.[index] || dataPoint.name || `Day ${index + 1}`
+            name: String(metadata?.xTickLabels?.[index] || dataPoint.name || `Day ${index + 1}`)
         };
     });
     
@@ -140,53 +96,13 @@ export default function EnergyProfileGraph({
                         />
                     </div>
                     <div className="flex-1 min-h-0">
-                        <ResponsiveContainer width="100%" height="100%">
-                            <ComposedChart
-                                data={finalChartData}
-                                margin={{
-                                    top: 20,
-                                    right: 30,
-                                    left: 20,
-                                    bottom: 5,
-                                }}
-                            >
-                                <CartesianGrid strokeDasharray="3 3" />
-                                <XAxis 
-                                    dataKey="name" 
-                                    interval={Math.floor(finalChartData.length / 12)} // Show every Nth tick for ~12 labels
-                                    tick={{ fontSize: 14 }}
-                                />  
-                                <YAxis label={(props: any) => <CustomYAxisLabel {...props} metadata={metadata} />}  tick={{ fontSize: 14 }} />
-                                <Tooltip content={<CustomTooltip />} />
-                                <ReferenceLine y={0} stroke="#666" strokeWidth={1} />
-                              
-                                {dataKeys.map((key, index) => {
-                                    const demandSupply = metadata?.properties?.[key]?.demandSupply;
-                                    const stackId = demandSupply === 'Vraag' ? 'demand' : 'supply';
-                                    
-                                    return (
-                                        <Area 
-                                            key={key}
-                                            type="monotone" 
-                                            dataKey={key} 
-                                            stackId={stackId}
-                                            stroke={metadata?.properties?.[key]?.color || colors[index % colors.length]} 
-                                            fill={metadata?.properties?.[key]?.color || colors[index % colors.length]} 
-                                        />
-                                    );
-                                })}
-                                {hasBasislast && (
-                                    <Line
-                                        type="monotone"
-                                        dataKey="Basislast elektriciteitsvraag"
-                                        stroke={metadata?.properties?.['Basislast elektriciteitsvraag']?.color || '#ff0000'}
-                                        strokeWidth={3}
-                                        strokeDasharray="3 3"
-                                        dot={false}
-                                    />
-                                )}
-                            </ComposedChart>
-                        </ResponsiveContainer>
+                        <EnergyProfileChart
+                            chartData={finalChartData}
+                            metadata={metadata}
+                            dataKeys={dataKeys}
+                            hasBasislast={hasBasislast}
+                            colors={colors}
+                        />
                     </div>
                      </div>
                 )}

--- a/app/frontend/components/Graph/FilterSection.tsx
+++ b/app/frontend/components/Graph/FilterSection.tsx
@@ -35,7 +35,7 @@ export default function FilterSection({
                             <Checkbox
                                 id={item.name}
                                 value={item.name}
-                                defaultChecked={selectedItems.includes(item.name)}
+                                checked={selectedItems.includes(item.name)}
                                 onCheckedChange={() => onToggleItem(item.name)}
                             />
                             <label htmlFor={item.name} className="mx-4">

--- a/app/frontend/components/Graph/FilterSection.tsx
+++ b/app/frontend/components/Graph/FilterSection.tsx
@@ -1,4 +1,4 @@
-import { Checkbox } from '../../ui/checkbox';
+import { Checkbox } from '../ui/checkbox';
 import { FilterSectionProps } from '@/types/components/Graph';
 
 
@@ -8,6 +8,7 @@ export default function FilterSection({
     selectedItems,
     onToggleItem,
     legendData,
+    reverseOrder = true,
 }: FilterSectionProps) {
     // Group items by demandSupply to show separator
     const groupedItems = items.reduce((acc, item) => {
@@ -20,7 +21,7 @@ export default function FilterSection({
 
     const groups = Object.entries(groupedItems).map(([demandSupply, groupItems]) => [
         demandSupply,
-        groupItems.slice().reverse()
+        reverseOrder ? groupItems.slice().reverse() : groupItems
     ]);
 
     return (
@@ -40,10 +41,17 @@ export default function FilterSection({
                             <label htmlFor={item.name} className="mx-4">
                                 {item.name}
                             </label>
-                            <div
-                                className="absolute right-[-8px] top-1 w-4 h-4 ml-2 mr-1 border rounded border-gray-300"
-                                style={{ backgroundColor: legendData[item.name] }}
-                            />
+                            {item.name === "Basislast elektriciteitsvraag" ? (
+                                <div
+                                    className="absolute right-[-8px] top-2 w-4 h-0 ml-2 mr-1 border-t-2 border-dashed"
+                                    style={{ borderColor: legendData[item.name] }}
+                                />
+                            ) : (
+                                <div
+                                    className="absolute right-[-8px] top-1 w-4 h-4 ml-2 mr-1 border rounded border-gray-300"
+                                    style={{ backgroundColor: legendData[item.name] }}
+                                />
+                            )}
                         </div>
                     ))}
                     {/* Add separator line between groups (except after the last group) */}

--- a/app/frontend/components/Graph/FilterSection.tsx
+++ b/app/frontend/components/Graph/FilterSection.tsx
@@ -8,7 +8,7 @@ export default function FilterSection({
     selectedItems,
     onToggleItem,
     legendData,
-    reverseOrder = true,
+    reverseOrder = {},
 }: FilterSectionProps) {
     // Group items by demandSupply to show separator
     const groupedItems = items.reduce((acc, item) => {
@@ -21,7 +21,7 @@ export default function FilterSection({
 
     const groups = Object.entries(groupedItems).map(([demandSupply, groupItems]) => [
         demandSupply,
-        reverseOrder ? groupItems.slice().reverse() : groupItems
+        reverseOrder[demandSupply] ? groupItems.slice().reverse() : groupItems
     ]);
 
     return (

--- a/app/frontend/types/components/EnergyProfileGraph.ts
+++ b/app/frontend/types/components/EnergyProfileGraph.ts
@@ -1,3 +1,4 @@
+import { GraphDataPoint } from "./Graph";
 export interface EnergyProfileGraphProps {
     enabled?: boolean;
 }
@@ -17,4 +18,12 @@ export interface GraphMetadata {
 export interface GraphResponse {
     metaData: GraphMetadata;
     graphData: GraphData[];
+}
+
+export interface EnergyProfileChartProps {
+    chartData: GraphDataPoint[];
+    metadata: GraphMetadata;
+    dataKeys: string[];
+    hasBasislast: boolean;
+    colors: string[];
 }

--- a/app/frontend/types/components/Graph.ts
+++ b/app/frontend/types/components/Graph.ts
@@ -47,6 +47,6 @@ export interface FilterSectionProps {
     selectedItems: string[];
     onToggleItem: (item: string) => void;
     legendData: Record<string, string>;
-    reverseOrder?: boolean;
+    reverseOrder?: Record<string, boolean>;
 }
 

--- a/app/frontend/types/components/Graph.ts
+++ b/app/frontend/types/components/Graph.ts
@@ -47,5 +47,6 @@ export interface FilterSectionProps {
     selectedItems: string[];
     onToggleItem: (item: string) => void;
     legendData: Record<string, string>;
+    reverseOrder?: boolean;
 }
 

--- a/hail/config/results/graphs/energybalance_curve.py
+++ b/hail/config/results/graphs/energybalance_curve.py
@@ -166,7 +166,7 @@ class ElectricityBalanceCurve(AbstractResultCurveGraph):
                 value=var.gqueries.households_flexibility_p2p_electricity.future,
                 color="#92896B",
                 name="Thuisbatterijen",
-                group="batterijen",
+                group="Batterijen",
                 demandSupply="Aanbod",
             ),
             GraphCurveElement(


### PR DESCRIPTION
This PR updates the Energy Profile Chart: 
- Adds a legenda to the chart
- Adds func that the chart view can be updates when you click on the items in the legenda
- Orders items in the legenda to have the same build up as in the chart
- Updates the hover to round up to two decimals
- Updates the hover to show the items in the same order as the graph + Vraag/Aanbod together

Zooming has not been implemented. This is not possible out-of-the-box in recharts, so I'll create a separate item for this on the backlog. 


Please note: other PR should be reviewed and merged first, as this contains updates to packages frontend. 

<img width="1026" height="1055" alt="image" src="https://github.com/user-attachments/assets/e22afca2-270a-4727-be2f-3326cd707edf" />
